### PR TITLE
dummy 4th element to satisfy spec

### DIFF
--- a/lib/stupidedi/versions/functional_groups/004010/segment_defs/PO4.rb
+++ b/lib/stupidedi/versions/functional_groups/004010/segment_defs/PO4.rb
@@ -16,6 +16,7 @@ module Stupidedi
             e::E357 .simple_use(r::Optional,   s::RepeatCount.bounded(1)),
             e::E355 .simple_use(r::Relational, s::RepeatCount.bounded(1)),
             e::E187 .simple_use(r::Optional, s::RepeatCount.bounded(1)),
+            e::E187 .simple_use(r::Optional, s::RepeatCount.bounded(1)),
             e::E384 .simple_use(r::Optional, s::RepeatCount.bounded(1)),
             e::E355 .simple_use(r::Optional, s::RepeatCount.bounded(1)))
         end


### PR DESCRIPTION
4th element appears in syntax notes but not in 'Data Element Summary'